### PR TITLE
Support for base path

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,5 +9,6 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true
+  "node": true,
+  "esnext": true
 }

--- a/tasks/ssnt.js
+++ b/tasks/ssnt.js
@@ -5,51 +5,28 @@
  * Copyright (c) 2015 Ted Flynn
  * Licensed under the MIT license.
  */
-
 'use strict';
 
-var nunjucks = require('nunjucks');
+const nunjucks = require('nunjucks');
 
-var NunjucksTemplate = function(grunt, task) {
 
-    this.templateGlobals = {};
-    this.grunt = grunt;
-    this.files = task.files;
-    this.options = task.options();
+module.exports = function (grunt) {
 
-    if (this.options.nunjucksDefaults) {
-        nunjucks.configure(this.options.nunjucksDefaults);
-    }
+    grunt.registerMultiTask('ssnt', 'Compiles Nunjucks templates with Grunt.', function () {
 
-    if (this.options.templateGlobals) {
-        this.templateGlobals = this.options.templateGlobals;
-    }
+        const options = Object.assign({
+            templateGlobals: {},
+            basePath: '.',
+            nunjucksDefaults: {}
+        }, this.options());
+        const env = nunjucks.configure(options.basePath, options.nunjucksDefaults);
 
-    this.renderTemplates();
-};
-
-var proto = NunjucksTemplate.prototype;
-
-proto.renderTemplates = function() {
-    var grunt = this.grunt;
-    var files = this.files;
-    var options = this.options;
-    var templateGlobals = this.templateGlobals;
-
-    files.forEach(function(file, index) {
-        var src = file.src[0];
-
-        grunt.log.write('Processing: "%s"' + '\n', src);
-
-        grunt.file.write(file.dest, nunjucks.render(src, templateGlobals));
+        this.files.forEach(file => {
+            const src = file.src[0];
+            grunt.log.write('Processing: "%s"' + '\n', src);
+            grunt.file.write(file.dest, env.render(src, options.templateGlobals));
+        });
 
     });
 
-    return this;
-};
-
-module.exports = function(grunt) {
-    grunt.registerMultiTask('ssnt', 'Compiles Nunjucks templates with Grunt.', function() {
-        new NunjucksTemplate(grunt, this);
-  });
 };

--- a/tasks/ssnt.js
+++ b/tasks/ssnt.js
@@ -8,6 +8,7 @@
 'use strict';
 
 const nunjucks = require('nunjucks');
+const path = require('path');
 
 
 module.exports = function (grunt) {
@@ -22,7 +23,7 @@ module.exports = function (grunt) {
         const env = nunjucks.configure(options.basePath, options.nunjucksDefaults);
 
         this.files.forEach(file => {
-            const src = file.src[0];
+            const src = path.resolve(file.src[0]);
             grunt.log.write('Processing: "%s"' + '\n', src);
             grunt.file.write(file.dest, env.render(src, options.templateGlobals));
         });


### PR DESCRIPTION
This adds support for a `basePath` option so other files don't need to be referenced with relative paths inside the templates.

```js
ssnt: {
    target: {
        options: {
            basePath: '<%= env.DIR_SRC %>'
        }
    }
}
```

Then in the markup,

```twig
{% include "templates/partials/_hero.html" %}
```

By default (without the basePath specified), it's the same behavior as before.

I also refactored it away from a class-based pattern to a more functional one for simplicity. I could see that being an issue philosophically, and I don't have strong inclinations either way so if you want to keep the OO way, I can create a new pull request.